### PR TITLE
Handle edge cases for houses and hotels

### DIFF
--- a/GameClient/GameClient.csproj
+++ b/GameClient/GameClient.csproj
@@ -145,7 +145,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Resource Include="monopoly_icon_256_BG2_icon.ico" />
+    <Resource Include="Assets\MonopolyDealIcon.ico" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0,Profile=Client">

--- a/GameClient/GameWindow.xaml.cs
+++ b/GameClient/GameWindow.xaml.cs
@@ -1025,7 +1025,7 @@ namespace GameClient
                     List<Card> monopoly = (4 == cardBeingAdded.ActionID ) ? ClientUtilities.FindMonopolyWithoutHouse(player) : ClientUtilities.FindMonopolyWithoutHotel(player);
                     if ( null != monopoly && 
                         MessageBoxResult.Yes == MessageBox.Show("Adding a " + cardBeingAdded.Name + " to your monopoly will prevent you from being able to separate any " + 
-                                                                "property wild cards from the set unless you have another monopoly you can move the + " + cardBeingAdded.Name + " to. \n\n" +
+                                                                "property wild cards from the set unless you have another monopoly that you can move the " + cardBeingAdded.Name + " to. \n\n" +
                                                                 "Are you sure you want to do this?", 
                                                                 "Are you sure you want to play your " + cardBeingAdded.Name + "?", MessageBoxButton.YesNo) )
                     {
@@ -1917,21 +1917,28 @@ namespace GameClient
                 }
 
                 // If there are any card lists that contain an enhancement card but are not monopolies, then place the enhancement card(s) in the player's bank.
+                bool enhancementsWereConverted = false;
                 List<List<Card>> nonMonopolies = this.Player.CardsInPlay.Where(cardList => !ClientUtilities.IsCardListMonopoly(cardList)).ToList<List<Card>>();
                 foreach ( List<Card> cardList in nonMonopolies )
                 {
                     List<Card> enhancements = cardList.Where(card => card.Type == CardType.Enhancement).ToList<Card>();
                     foreach (Card enhancement in enhancements)
-                    {                            
+                    {
                         RemoveCardFromCardsInPlay(enhancement, this.Player);
-
                         enhancement.Type = CardType.Money;
-                        AddCardToCardsInPlay(enhancement, this.Player);                         
+                        AddCardToCardsInPlay(enhancement, this.Player);
+
+                        enhancementsWereConverted = true;
                     }                 
                 }
                 
                 // Display this player's updated CardsInPlay.
                 DisplayCardsInPlay(this.Player, PlayerOneField);
+
+                if ( enhancementsWereConverted )
+                {
+                    MessageBox.Show("The Houses/Hotels on any full sets that you needed to break up were converted to money and placed in your bank.");
+                }
             }
             else
             {

--- a/GameClient/GameWindow.xaml.cs
+++ b/GameClient/GameWindow.xaml.cs
@@ -1023,15 +1023,18 @@ namespace GameClient
                 case CardType.Enhancement:
                 {
                     List<Card> monopoly = (4 == cardBeingAdded.ActionID ) ? ClientUtilities.FindMonopolyWithoutHouse(player) : ClientUtilities.FindMonopolyWithoutHotel(player);
-                    if ( null != monopoly )
+                    if ( null != monopoly && 
+                        MessageBoxResult.Yes == MessageBox.Show("Adding a " + cardBeingAdded.Name + " to your monopoly will prevent you from being able to separate any " + 
+                                                                "property wild cards from the set unless you have another monopoly you can move the + " + cardBeingAdded.Name + " to. \n\n" +
+                                                                "Are you sure you want to do this?", 
+                                                                "Are you sure you want to play your " + cardBeingAdded.Name + "?", MessageBoxButton.YesNo) )
                     {
                         monopoly.Add(cardBeingAdded);
                         AddCardToGrid(cardBeingAdded, PlayerFieldDictionary[player.Name], player, false, player.CardsInPlay.IndexOf(monopoly));
 
                         return true;
                     }
-
-                    // Do not add the house or hotel if the code is reached.
+                    
                     return false;
                 }
                 case CardType.Money:
@@ -1911,6 +1914,20 @@ namespace GameClient
                     {
                         this.Player.MoneyList.Remove(card);
                     }
+                }
+
+                // If there are any card lists that contain an enhancement card but are not monopolies, then place the enhancement card(s) in the player's bank.
+                List<List<Card>> nonMonopolies = this.Player.CardsInPlay.Where(cardList => !ClientUtilities.IsCardListMonopoly(cardList)).ToList<List<Card>>();
+                foreach ( List<Card> cardList in nonMonopolies )
+                {
+                    List<Card> enhancements = cardList.Where(card => card.Type == CardType.Enhancement).ToList<Card>();
+                    foreach (Card enhancement in enhancements)
+                    {                            
+                        RemoveCardFromCardsInPlay(enhancement, this.Player);
+
+                        enhancement.Type = CardType.Money;
+                        AddCardToCardsInPlay(enhancement, this.Player);                         
+                    }                 
                 }
                 
                 // Display this player's updated CardsInPlay.

--- a/GameClient/GameWindow.xaml.cs
+++ b/GameClient/GameWindow.xaml.cs
@@ -992,12 +992,6 @@ namespace GameClient
 
                     if ( PropertyType.Wild != cardBeingAdded.Color )
                     {
-                        // ROBIN TODO: Instead of doing nothing and returning false, the card should be added to a new list.
-                        //if ( colorsOfCurrentMonopolies.Contains(cardBeingAdded.Color) )
-                        //{
-                        //    return false;
-                        //}
-
                         // If the card has passed the previous check, add it to the player's CardsInPlay.
                         for ( int i = 1; i < player.CardsInPlay.Count; ++i )
                         {
@@ -1149,8 +1143,6 @@ namespace GameClient
                         {
                             item.IsEnabled &= (this.Turn.ActionsRemaining > 0);
                         }
-                       //item.IsEnabled = isCurrentTurnOwner && 
-                       //                 ((ResourceList.DiscardMenuItemHeader == (string)item.Header) || (this.Turn.ActionsRemaining > 0));
                     }
                 };
 
@@ -1168,7 +1160,7 @@ namespace GameClient
                     if ( HasAltColor(cardBeingAdded) )
                     {
                         MenuItem flipMenuItem = new MenuItem();
-                        flipMenuItem.Header = "Flip Card";
+                        flipMenuItem.Header = ResourceList.FlipCardMenuItemHeader;
                         flipMenuItem.Click += ( sender2, args2 ) =>
                         {
                             // Flip the card, swapping its primary and alternative colors.
@@ -1217,7 +1209,6 @@ namespace GameClient
                         };
                         menu.Items.Add(playAsActionMenuItem);
                     }
-
 
                     MenuItem playAsMoneyMenuItem = new MenuItem();
                     playAsMoneyMenuItem.Header = "Play as Money";
@@ -1273,7 +1264,7 @@ namespace GameClient
                             if ( HasAltColor(cardBeingAdded) )
                             {
                                 MenuItem flipMenuItem = new MenuItem();
-                                flipMenuItem.Header = "Flip Card";
+                                flipMenuItem.Header = ResourceList.FlipCardMenuItemHeader;
                                 flipMenuItem.Click += ( sender, args ) =>
                                 {
                                     // Check to see if the flipped card can be added to the player's CardsInPlay.
@@ -1290,26 +1281,6 @@ namespace GameClient
 
                                     // Flip the card, swapping its primary and alternative colors.
                                     FlipCard(cardBeingAdded);
-
-                                    // Place the house/hotel in a separate list that can be accessed whenever the player wants to play a house/hotel or use it as money.
-                                    List<Card> cardListContainingCard = FindListContainingCard(cardBeingAdded);
-
-                                    // Get all of the cards that are enhancements.
-                                    List<Card> enhancements = cardListContainingCard.FindAll(card => CardType.Enhancement == card.Type);
-
-                                    if ( null != enhancements && enhancements.Count > 0 )
-                                    {
-                                        foreach ( Card enhancement in enhancements )
-                                        {
-                                            // Remove the card from the field.
-                                            RemoveCardFromCardsInPlay(enhancement, this.Player);
-
-                                            // Add the card to the pile of Enhancement cards.
-                                            // These cards are located at the last index in the grid.
-                                            Grid field = PlayerFieldDictionary[this.Player.Name];
-                                            AddCardToGrid(enhancement, field, this.Player, false, field.ColumnDefinitions.Count - 1);
-                                        }
-                                    }
 
                                     // Remove the card and re-add it to the Player's CardsInPlay.
                                     RemoveCardFromCardsInPlay(cardBeingAdded, this.Player);
@@ -1329,7 +1300,7 @@ namespace GameClient
                             else if ( PropertyType.Wild == cardBeingAdded.Color )
                             {
                                 MenuItem separateMenuItem = new MenuItem();
-                                separateMenuItem.Header = "Separate Wild Card";
+                                separateMenuItem.Header = ResourceList.SeparateWildCardMenuItemHeader;
                                 separateMenuItem.Click += ( sender, args ) =>
                                 {
                                     // Remove the card from its previous position on the player's playing field.
@@ -1357,6 +1328,13 @@ namespace GameClient
                                 foreach ( MenuItem item in menu.Items )
                                 {
                                     item.IsEnabled = this.IsCurrentTurnOwner;
+
+                                    string header = (string)item.Header;
+                                    if ( ResourceList.FlipCardMenuItemHeader == header || ResourceList.SeparateWildCardMenuItemHeader == header )
+                                    {
+                                        List<Card> cardListContainingCard = FindListContainingCard(cardBeingAdded);
+                                        item.IsEnabled &= !(cardListContainingCard.Any(card => (int)ActionId.House == card.ActionID));
+                                    }
                                 }
                             };
 

--- a/GameClient/Properties/Resources.Designer.cs
+++ b/GameClient/Properties/Resources.Designer.cs
@@ -77,5 +77,23 @@ namespace GameClient.Properties {
                 return ResourceManager.GetString("DiscardMenuItemHeader", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Flip Card.
+        /// </summary>
+        internal static string FlipCardMenuItemHeader {
+            get {
+                return ResourceManager.GetString("FlipCardMenuItemHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Separate Wild Card.
+        /// </summary>
+        internal static string SeparateWildCardMenuItemHeader {
+            get {
+                return ResourceManager.GetString("SeparateWildCardMenuItemHeader", resourceCulture);
+            }
+        }
     }
 }

--- a/GameClient/Properties/Resources.resx
+++ b/GameClient/Properties/Resources.resx
@@ -123,4 +123,10 @@
   <data name="DiscardMenuItemHeader" xml:space="preserve">
     <value>Discard</value>
   </data>
+  <data name="FlipCardMenuItemHeader" xml:space="preserve">
+    <value>Flip Card</value>
+  </data>
+  <data name="SeparateWildCardMenuItemHeader" xml:space="preserve">
+    <value>Separate Wild Card</value>
+  </data>
 </root>

--- a/GameObjects/ActionId.cs
+++ b/GameObjects/ActionId.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace GameObjects
+{
+    // Enum used to represent the type of an action card.
+    // Do not change the order of these values, as the integer representations are used in the configuration.
+    public enum ActionId
+    {
+        PassGo,
+        DoubleTheRent,
+        JustSayNo,
+        Hotel,
+        House,
+        DealBreaker,
+        SlyDeal,
+        ForcedDeal,
+        ItsMyBirthday,
+        DebtCollector,
+        RentWild,
+        RentLightBlueBrown,
+        RentOrangePink,
+        RentYellowRed,
+        RentUtilityRailroad,
+        RentBlueGreen
+    }
+}

--- a/GameObjects/GameObjects.csproj
+++ b/GameObjects/GameObjects.csproj
@@ -46,6 +46,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ActionId.cs" />
     <Compile Include="Cards\Card.cs" />
     <Compile Include="Cards\EnhancementCard.cs" />
     <Compile Include="MoneyList.cs" />


### PR DESCRIPTION
The purpose of this change is to handle special scenarios related to the playing of house and hotel cards. Specifically, the following actions require that a house/hotel be dealt with:

1. A player flips a property that is part of a monopoly
2. A player separates a Property Wild Card from a monopoly
3. A a player uses part of a monopoly to pay off rent

It was decided that actions (1) and (2) would be disabled if a house/hotel exists on a set. When action (3) occurs, the houses/hotels on the set are automatically moved to the player's bank.