### PR TITLE
Batch of changes to address minor feedback

### DIFF
--- a/AdditionalWindows/AdditionalWindows.csproj
+++ b/AdditionalWindows/AdditionalWindows.csproj
@@ -64,6 +64,7 @@
     <Compile Include="RentWindow.xaml.cs">
       <DependentUpon>RentWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="CardImageConverter.cs" />
     <Compile Include="StaticResourceConverter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AdditionalWindows/CardImageConverter.cs
+++ b/AdditionalWindows/CardImageConverter.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Markup;
+using System.Windows.Media;
+using System.Xaml;
+using GameObjects;
+using Utilities;
+
+namespace AdditionalWindows
+{
+    class CardImageConverter : MarkupExtension, IValueConverter
+    {
+        private Control _target;
+
+        public object Convert( object value, Type targetType, object parameter, CultureInfo culture )
+        {
+            var card = value as Card;
+            if ( card == null )
+                return null;
+
+            DrawingImage cardImage = null;
+            if ( _target != null )
+            {
+                cardImage = _target.TryFindResource(card.CardImageUriPath) as DrawingImage;
+            }
+            if ( cardImage == null )
+            {
+                cardImage = Application.Current.TryFindResource(card.CardImageUriPath) as DrawingImage;
+            }
+            if ( cardImage == null )
+                return null;
+
+            return ClientUtilities.AddCardCountToCardImage(cardImage, card.TotalCount);
+        }
+
+        public object ConvertBack( object value, Type targetType, object parameter, CultureInfo culture )
+        {
+            throw new NotSupportedException();
+        }
+
+        public override object ProvideValue( IServiceProvider serviceProvider )
+        {
+            var rootObjectProvider = serviceProvider.GetService(typeof(IRootObjectProvider)) as IRootObjectProvider;
+            if ( rootObjectProvider == null )
+                return this;
+
+            _target = rootObjectProvider.RootObject as Control;
+            return this;
+        }
+    }
+}

--- a/AdditionalWindows/CardImageConverter.cs
+++ b/AdditionalWindows/CardImageConverter.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Globalization;
-using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Markup;
-using System.Windows.Media;
 using System.Xaml;
 using GameObjects;
 using Utilities;
@@ -21,19 +19,7 @@ namespace AdditionalWindows
             if ( card == null )
                 return null;
 
-            DrawingImage cardImage = null;
-            if ( _target != null )
-            {
-                cardImage = _target.TryFindResource(card.CardImageUriPath) as DrawingImage;
-            }
-            if ( cardImage == null )
-            {
-                cardImage = Application.Current.TryFindResource(card.CardImageUriPath) as DrawingImage;
-            }
-            if ( cardImage == null )
-                return null;
-
-            return ClientUtilities.AddCardCountToCardImage(cardImage, card.TotalCount);
+            return ClientUtilities.ConvertCardToImage(_target, card);
         }
 
         public object ConvertBack( object value, Type targetType, object parameter, CultureInfo culture )

--- a/AdditionalWindows/PropertyTheftWindow.xaml.cs
+++ b/AdditionalWindows/PropertyTheftWindow.xaml.cs
@@ -240,8 +240,10 @@ namespace AdditionalWindows
                         }
                         else
                         {
+                            var cardImage = this.TryFindResource(property.CardImageUriPath) as DrawingImage;
+                            cardImage = ClientUtilities.AddCardCountToCardImage(cardImage, property.TotalCount);
                             Image tooltip = new Image();
-                            tooltip.Source = this.TryFindResource(property.CardImageUriPath) as DrawingImage;
+                            tooltip.Source = cardImage;
                             tooltip.MaxWidth = Convert.ToInt32(GameObjectsResourceList.TooltipMaxWidth);
                             propertyItem.ToolTip = tooltip;
                         }

--- a/AdditionalWindows/PropertyTheftWindow.xaml.cs
+++ b/AdditionalWindows/PropertyTheftWindow.xaml.cs
@@ -1,16 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
-using System.Collections;
 using System.ComponentModel;
 using System.Collections.ObjectModel;
 using GameObjects;
@@ -240,10 +232,8 @@ namespace AdditionalWindows
                         }
                         else
                         {
-                            var cardImage = this.TryFindResource(property.CardImageUriPath) as DrawingImage;
-                            cardImage = ClientUtilities.AddCardCountToCardImage(cardImage, property.TotalCount);
                             Image tooltip = new Image();
-                            tooltip.Source = cardImage;
+                            tooltip.Source = ClientUtilities.ConvertCardToImage(this, property);
                             tooltip.MaxWidth = Convert.ToInt32(GameObjectsResourceList.TooltipMaxWidth);
                             propertyItem.ToolTip = tooltip;
                         }

--- a/AdditionalWindows/RentWindow.xaml.cs
+++ b/AdditionalWindows/RentWindow.xaml.cs
@@ -99,7 +99,7 @@ namespace AdditionalWindows
         private void GiveAllButton_Click( object sender, RoutedEventArgs e )
         {
             AssetsListView.SelectAll();
-            TransferSelectedItems(AssetsListView, PaymentListView);
+            TransferSelectedItems(AssetsListView, PaymentListView, isGiveAll: true);
         }
 
         private void RemoveAllButton_Click( object sender, RoutedEventArgs e )
@@ -109,7 +109,7 @@ namespace AdditionalWindows
         }
 
         // Transfer all selected items from one listview to another.
-        private void TransferSelectedItems(ListView listview1, ListView listview2)
+        private void TransferSelectedItems(ListView listview1, ListView listview2, bool isGiveAll = false)
         {
             List<Card> selectedCards = new List<Card>();
 
@@ -121,6 +121,13 @@ namespace AdditionalWindows
             // which modifies the value of the SelectedItems collection.
             foreach ( Card card in listview1.SelectedItems )
             {
+                // Do not include 0-value card in selection for GiveAll operation since player likely does not want to give this.
+                // This really only applies to the Property Wild Card.
+                if ( isGiveAll && card.Value == 0 )
+                {
+                    continue;
+                }
+
                 selectedCards.Add(card);
             }
 

--- a/AdditionalWindows/Styles/CardListView.xaml
+++ b/AdditionalWindows/Styles/CardListView.xaml
@@ -20,7 +20,7 @@
                 <Style TargetType="{x:Type ListViewItem}">
                     <Setter Property="ToolTip">
                         <Setter.Value>
-                            <Image Source="{Binding CardImageUriPath, Converter={local:StaticResourceConverter} }"
+                            <Image Source="{Binding Converter={local:CardImageConverter}}"
                                    MaxWidth="200"/>
                         </Setter.Value>
                     </Setter>

--- a/GameClient/EventLog.xaml.cs
+++ b/GameClient/EventLog.xaml.cs
@@ -209,6 +209,7 @@ namespace GameClient
                         {
                             Card card = this.allCards[cardId];
                             DrawingImage cardImageSource = this.TryFindResource(card.CardImageUriPath) as DrawingImage;
+                            cardImageSource = ClientUtilities.AddCardCountToCardImage(cardImageSource, card.TotalCount);
                             var cardGraphic = new TextBlock()
                             {
                                 TextWrapping = TextWrapping.Wrap,

--- a/GameClient/EventLog.xaml.cs
+++ b/GameClient/EventLog.xaml.cs
@@ -5,13 +5,8 @@ using System.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using GameObjects;
 using GameServer;
 using Lidgren.Network;
@@ -208,8 +203,7 @@ namespace GameClient
                              this.allCards.ContainsKey(cardId))
                         {
                             Card card = this.allCards[cardId];
-                            DrawingImage cardImageSource = this.TryFindResource(card.CardImageUriPath) as DrawingImage;
-                            cardImageSource = ClientUtilities.AddCardCountToCardImage(cardImageSource, card.TotalCount);
+                            DrawingImage cardImageSource = ClientUtilities.ConvertCardToImage(this, card);
                             var cardGraphic = new TextBlock()
                             {
                                 TextWrapping = TextWrapping.Wrap,

--- a/GameClient/GameWindow.xaml.cs
+++ b/GameClient/GameWindow.xaml.cs
@@ -1007,9 +1007,12 @@ namespace GameClient
             // Otherwise, display only the last card in the discard pile.
             else
             {
-                Card discardedCard = this.DiscardPile[this.DiscardPile.Count - 1];
-                this.DiscardPileDisplay.DisplayImage = this.TryFindResource(discardedCard.CardImageUriPath) as DrawingImage;
+                Card discardedCard = this.DiscardPile[this.DiscardPile.Count - 1];                
                 this.DiscardPileDisplay.CardCount = this.DiscardPile.Count;
+
+                var cardImage = this.TryFindResource(discardedCard.CardImageUriPath) as DrawingImage;
+                cardImage = ClientUtilities.AddCardCountToCardImage(cardImage, this.DiscardPile.Count);
+                this.DiscardPileDisplay.DisplayImage = cardImage;
             }
         }
 
@@ -1063,8 +1066,18 @@ namespace GameClient
             cardContentImage.Source = this.TryFindResource(card.CardImageUriPath) as DrawingImage;
             cardButton.Content = cardContentImage;
 
+            /* TODO: Apply this to other areas of the app that have card tooltips.
+             * As of now, this only applies to cards on your hand or field
+             * Consider the following:
+             *    - (done) Discard pile
+             *    - (done) Event log
+             *    - Rent/Theft dialogs
+             */
+            var cardImage = this.TryFindResource(card.CardImageUriPath) as DrawingImage;
+            cardImage = ClientUtilities.AddCardCountToCardImage(cardImage, card.TotalCount);
+
             var cardTooltipImage = new Image();
-            cardTooltipImage.Source = this.TryFindResource(card.CardImageUriPath) as DrawingImage;
+            cardTooltipImage.Source = cardImage;
             cardTooltipImage.MaxWidth = Convert.ToInt32(GameObjectsResourceList.TooltipMaxWidth);
             cardTooltipImage.RenderTransform = new TransformGroup();
             cardTooltipImage.RenderTransformOrigin = new Point(0.5, 0.5);
@@ -1860,13 +1873,6 @@ namespace GameClient
         // Draw a given amount of cards from the Deck (the cards are placed in the Player's hand).
         private void DrawCards( int numberOfCards )
         {
-            //// Reset the Deck.
-            //Deck = null;
-            //ServerUtilities.SendMessage(Client, Datatype.RequestDeck);
-
-            //// Do not continue until the updated Deck is received from the server.
-            //while ( Deck == null ) ;
-
             if ( null != this.Deck )
             {
                 // Remove the given number of cards from the top of the Deck and add them to the Player's hand.
@@ -2684,6 +2690,7 @@ namespace GameClient
 
             return bellButton;
         }
+
         #endregion
 
     }

--- a/GameClient/GameWindow.xaml.cs
+++ b/GameClient/GameWindow.xaml.cs
@@ -2342,7 +2342,7 @@ namespace GameClient
                     Card justSayNo = this.Player.CardsInHand.FirstOrDefault(card => 2 == card.ActionID);
                     // If the renter has his own Just Say No, ask the renter if he wants to use it.
                     // If yes, send the rent request again.
-                    bool playerWantsToUseJustSayNo = this.AskPlayerAboutJustSayNo("Rest Request Rejected", message, playerHasJustSayNo: null != justSayNo);
+                    bool playerWantsToUseJustSayNo = this.AskPlayerAboutJustSayNo("Rent Request Rejected", message, playerHasJustSayNo: null != justSayNo);
                     if ( playerWantsToUseJustSayNo )
                     {
                         // By the time the renter presses "Yes", he may have already used all of his Just Say No cards. Verify that he still have one before moving on.

--- a/GameClient/GameWindow.xaml.cs
+++ b/GameClient/GameWindow.xaml.cs
@@ -1765,7 +1765,6 @@ namespace GameClient
                 case CardType.Property:
                 {
                     TransformGroup cardButtonTransformGroup = (cardButton.RenderTransform as TransformGroup);
-                    TransformGroup cardTooltipTransformGroup = (cardButton.ToolTip as Image).RenderTransform as TransformGroup;
 
                     // Flip or unflip a two-color property.
                     if ( HasAltColor(cardButton.Tag as Card) )
@@ -1774,14 +1773,12 @@ namespace GameClient
 
                         // First remove any rotate transform that may have been applied.
                         RemoveTransformTypeFromGroup(horizontalTransform.GetType(), cardButtonTransformGroup);
-                        RemoveTransformTypeFromGroup(horizontalTransform.GetType(), cardTooltipTransformGroup);
 
                         // Flip properties that are supposed to be flipped.
                         if ( card.IsFlipped )
                         {
                             horizontalTransform.Angle = 180;
                             cardButtonTransformGroup.Children.Add(horizontalTransform);
-                            cardTooltipTransformGroup.Children.Add(horizontalTransform);
                         }
                     }
 

--- a/GameClient/GameWindow.xaml.cs
+++ b/GameClient/GameWindow.xaml.cs
@@ -1010,9 +1010,7 @@ namespace GameClient
                 Card discardedCard = this.DiscardPile[this.DiscardPile.Count - 1];                
                 this.DiscardPileDisplay.CardCount = this.DiscardPile.Count;
 
-                var cardImage = this.TryFindResource(discardedCard.CardImageUriPath) as DrawingImage;
-                cardImage = ClientUtilities.AddCardCountToCardImage(cardImage, this.DiscardPile.Count);
-                this.DiscardPileDisplay.DisplayImage = cardImage;
+                this.DiscardPileDisplay.DisplayImage = ClientUtilities.ConvertCardToImage(this, discardedCard);
             }
         }
 
@@ -1066,15 +1064,7 @@ namespace GameClient
             cardContentImage.Source = this.TryFindResource(card.CardImageUriPath) as DrawingImage;
             cardButton.Content = cardContentImage;
 
-            /* TODO: Apply this to other areas of the app that have card tooltips.
-             * As of now, this only applies to cards on your hand or field
-             * Consider the following:
-             *    - (done) Discard pile
-             *    - (done) Event log
-             *    - Rent/Theft dialogs
-             */
-            var cardImage = this.TryFindResource(card.CardImageUriPath) as DrawingImage;
-            cardImage = ClientUtilities.AddCardCountToCardImage(cardImage, card.TotalCount);
+            var cardImage = ClientUtilities.ConvertCardToImage(this, card);
 
             var cardTooltipImage = new Image();
             cardTooltipImage.Source = cardImage;

--- a/GameObjects/Cards/Card.cs
+++ b/GameObjects/Cards/Card.cs
@@ -56,6 +56,11 @@ namespace GameObjects
         public int ActionID { get; set; }
         public int CardID { get; set; }
         public bool IsFlipped { get; set; }
+        
+        /// <summary>
+        /// The total count of this card in the game
+        /// </summary>
+        public int TotalCount { get; set; }
 
         // Constants
         public const int BIRTHDAY_AMOUNT = 2;
@@ -67,7 +72,18 @@ namespace GameObjects
             this.CardImageUriPath = String.Empty;
         }
 
-        public Card( string name, CardType type, int value, PropertyType color, PropertyType altColor, string uriPath, string soundUriPath, int actionID, int cardID, bool isFlipped = false ) // Create a card given a type, name, and value
+        public Card(
+            string name,
+            CardType type,
+            int value,
+            PropertyType color,
+            PropertyType altColor,
+            string uriPath,
+            string soundUriPath,
+            int actionID,
+            int cardID,
+            int totalCount,
+            bool isFlipped = false)
         {
             this.Name = name;
             this.Type = type;
@@ -78,6 +94,7 @@ namespace GameObjects
             this.CardSoundUriPath = soundUriPath;
             this.ActionID = actionID;
             this.CardID = cardID;
+            this.TotalCount = totalCount;
             this.IsFlipped = isFlipped;
         }
 

--- a/GameObjects/Deck.cs
+++ b/GameObjects/Deck.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.IO;
-using System.Reflection;
-using System.Resources;
 using System.Collections;
 using tvToolbox;
 using ResourceList = GameObjects.Properties.Resources;
@@ -61,6 +57,7 @@ namespace GameObjects
             string uriPath;
             string soundUriPath;
             int actionID;
+            int totalCount;
             
             // Each card must have a unique ID.
             int cardID = 0;
@@ -79,13 +76,14 @@ namespace GameObjects
                     propertyType = (cardProfile.sValue("-PropertyType", "") == "") ? PropertyType.None : (PropertyType)Enum.Parse(typeof(PropertyType), cardProfile.sValue("-PropertyType", ""));
                     altPropertyType = (cardProfile.sValue("-AltPropertyType", "") == "") ? PropertyType.None : (PropertyType)Enum.Parse(typeof(PropertyType), cardProfile.sValue("-AltPropertyType", ""));
                     uriPath = resourceName.Replace("-", string.Empty) + "DrawingImage";
+                    totalCount = cardProfile.iValue("-Count", 0);
 
                     string soundEffectFileName = cardProfile.sValue("-SoundEffectFile", string.Empty);
                     soundUriPath = string.IsNullOrWhiteSpace(soundEffectFileName) ? ResourceList.UriPathEmpty : ResourceList.UriPathAudioFolder + soundEffectFileName;
 
                     actionID = (cardProfile.sValue("-ActionID", "") == "") ? -1 : Convert.ToInt32((cardProfile.sValue("-ActionID", "")));
 
-                    cardList.Add(new Card(name, cardType, value, propertyType, altPropertyType, uriPath, soundUriPath, actionID, cardID));
+                    cardList.Add(new Card(name, cardType, value, propertyType, altPropertyType, uriPath, soundUriPath, actionID, cardID, totalCount));
 
                     // Iterate the card ID so that it is different for the next card.
                     cardID++;

--- a/Utilities/ClientUtilities.cs
+++ b/Utilities/ClientUtilities.cs
@@ -9,6 +9,7 @@ using System.Media;
 using System.IO;
 using System.Diagnostics;
 using tvToolbox;
+using System.Windows.Media;
 
 namespace Utilities
 {
@@ -231,6 +232,46 @@ namespace Utilities
         }
         #endregion
 
+        #region Card Rendering
+
+        public static DrawingImage AddCardCountToCardImage( DrawingImage originalImage, int cardCount )
+        {
+            DrawingGroup drawingGroup = new DrawingGroup();
+
+            // Add the original image to the group
+            drawingGroup.Children.Add(new ImageDrawing(originalImage, new Rect(0, 0, originalImage.Width, originalImage.Height)));
+
+            // Convert the number to string
+            string text = $"Total: {cardCount}";
+
+            // Create formatted text
+            FormattedText formattedText = new FormattedText(
+                text,
+                System.Globalization.CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface("Arial"),
+                36,
+                Brushes.Black);
+
+            // Calculate position to be centered along the bottom of the image
+            double xPosition = (originalImage.Width / 2) - (formattedText.Width / 2);
+            double yPosition = originalImage.Height - formattedText.Height - 6; // Add buffer from bottom edge
+
+            // Create a geometry for the text
+            Geometry textGeometry = formattedText.BuildGeometry(new Point(xPosition, yPosition));
+
+            // Create a GeometryDrawing for the text
+            GeometryDrawing textDrawing = new GeometryDrawing(Brushes.Black, null, textGeometry);
+
+            // Add the text drawing to the group
+            drawingGroup.Children.Add(textDrawing);
+
+            // Create and return a new DrawingImage
+            return new DrawingImage(drawingGroup);
+        }
+
+        #endregion
+        
         #region Sound
 
         public static void PlaySound( string uriPath )

--- a/Utilities/ClientUtilities.cs
+++ b/Utilities/ClientUtilities.cs
@@ -235,10 +235,11 @@ namespace Utilities
         public static DrawingImage ConvertCardToImage( FrameworkElement element, Card card )
         {
             DrawingImage cardImage = element?.TryFindResource(card.CardImageUriPath) as DrawingImage
-                ?? Application.Current.TryFindResource(card.CardImageUriPath) as DrawingImage;
-
+                ?? Application.Current?.TryFindResource(card.CardImageUriPath) as DrawingImage;
             if ( cardImage == null )
+            {
                 return null;
+            }
 
             // If the card is flipped, bake the rotation into the image before adding the count text,
             // so the text remains at the visual bottom after the flip.

--- a/Utilities/ClientUtilities.cs
+++ b/Utilities/ClientUtilities.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using GameObjects;
-using Lidgren.Network;
 using System.Windows;
 using System.Media;
 using System.IO;
@@ -234,7 +232,18 @@ namespace Utilities
 
         #region Card Rendering
 
-        public static DrawingImage AddCardCountToCardImage( DrawingImage originalImage, int cardCount )
+        public static DrawingImage ConvertCardToImage( FrameworkElement element, Card card )
+        {
+            DrawingImage cardImage = element?.TryFindResource(card.CardImageUriPath) as DrawingImage
+                ?? Application.Current.TryFindResource(card.CardImageUriPath) as DrawingImage;
+
+            if ( cardImage == null )
+                return null;
+
+            return AddCardCountToCardImage(cardImage, card.TotalCount);
+        }
+
+        private static DrawingImage AddCardCountToCardImage( DrawingImage originalImage, int cardCount )
         {
             DrawingGroup drawingGroup = new DrawingGroup();
 

--- a/Utilities/ClientUtilities.cs
+++ b/Utilities/ClientUtilities.cs
@@ -240,9 +240,20 @@ namespace Utilities
             if ( cardImage == null )
                 return null;
 
+            // If the card is flipped, bake the rotation into the image before adding the count text,
+            // so the text remains at the visual bottom after the flip.
+            if ( card.IsFlipped )
+            {
+                DrawingGroup flippedGroup = new DrawingGroup();
+                flippedGroup.Children.Add(new ImageDrawing(cardImage, new Rect(0, 0, cardImage.Width, cardImage.Height)));
+                flippedGroup.Transform = new RotateTransform(180, cardImage.Width / 2, cardImage.Height / 2);
+                cardImage = new DrawingImage(flippedGroup);
+            }
+
             return AddCardCountToCardImage(cardImage, card.TotalCount);
         }
 
+        // Add a label that displays the total count of this card on the bottom of the card
         private static DrawingImage AddCardCountToCardImage( DrawingImage originalImage, int cardCount )
         {
             DrawingGroup drawingGroup = new DrawingGroup();

--- a/Utilities/ServerUtilities.cs
+++ b/Utilities/ServerUtilities.cs
@@ -178,8 +178,21 @@ namespace GameServer
                 string soundUriPath = inc.ReadString();
                 string actionID = inc.ReadString();
                 string cardID = inc.ReadString();
+                string totalCount = inc.ReadString();
                 bool isFlipped = inc.ReadBoolean();
-                cards.Add(new Card(name, type, Convert.ToInt32(value), color, altColor, uriPath, soundUriPath, Convert.ToInt32(actionID), Convert.ToInt32(cardID), isFlipped));
+
+                cards.Add(new Card(
+                    name,
+                    type,
+                    Convert.ToInt32(value),
+                    color,
+                    altColor,
+                    uriPath,
+                    soundUriPath,
+                    Convert.ToInt32(actionID),
+                    Convert.ToInt32(cardID),
+                    Convert.ToInt32(totalCount),
+                    isFlipped));
             }
 
             return cards;
@@ -268,6 +281,7 @@ namespace GameServer
                     outmsg.Write(card.CardSoundUriPath);
                     outmsg.Write(card.ActionID.ToString());
                     outmsg.Write(card.CardID.ToString());
+                    outmsg.Write(card.TotalCount.ToString());
                     outmsg.Write(card.IsFlipped);
                 }
             }

--- a/Utilities/VolumeMixer.cs
+++ b/Utilities/VolumeMixer.cs
@@ -63,6 +63,10 @@ namespace Utilities
             IMMDeviceEnumerator deviceEnumerator = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
             IMMDevice speakers;
             deviceEnumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia, out speakers);
+            if ( speakers == null )
+            {
+                return null;
+            }
 
             // activate the session manager. we need the enumerator
             Guid IID_IAudioSessionManager2 = typeof(IAudioSessionManager2).GUID;


### PR DESCRIPTION
- Add a TotalCount label to the bottom of card tooltips that displays the total count of that card in the deck
- Exclude cards with value 0 (i.e. Property Wild Card) from the functionality of the Give All button when paying rent
- Fix bug where client wouldn't start if system didn't have any speakers (e.g. can happen during RDP session)